### PR TITLE
ci: fix ko builds with tag

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -32,10 +32,10 @@ jobs:
       - name: Push to GHCR
         run: ko build -B ./cmd/server
       - name: Push main branch to GHCR
-        if: github.ref_name == 'ci/push-branch-name'
+        if: github.ref_name == 'main'
         run: |
-          ko build --platform linux/amd64,linux/arm/v8,linux/arm64 --tags ${{ github.ref_name }}
+          ko build -B ./cmd/server --platform linux/amd64,linux/arm/v8,linux/arm64 --tags ${{ github.ref_name }}
       - name: Push tag to GHCR
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
-          ko build -B --platform linux/amd64,linux/arm/v8,linux/arm64 --tags ${{ github.ref_name }}
+          ko build -B ./cmd/server --platform linux/amd64,linux/arm/v8,linux/arm64 --tags ${{ github.ref_name }}

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -32,9 +32,9 @@ jobs:
       - name: Push to GHCR
         run: ko build -B ./cmd/server
       - name: Push main branch to GHCR
-        if: github.ref_name == 'main'
+        if: github.ref_name == 'ci/push-branch-name'
         run: |
-          ko build -B --platform linux/amd64,linux/arm/v8,linux/arm64 --tags ${{ github.ref_name }}
+          ko build --platform linux/amd64,linux/arm/v8,linux/arm64 --tags ${{ github.ref_name }}
       - name: Push tag to GHCR
         if: startsWith(github.ref, 'refs/tags/v')
         run: |


### PR DESCRIPTION
`ko` does not play nicely with `--tags` and `-B` for import paths.