### PR TITLE
feat: update snippet on cache hit

### DIFF
--- a/cmd/server/cmd.go
+++ b/cmd/server/cmd.go
@@ -118,7 +118,8 @@ func main() {
 			log.Printf("%s added to cache", snippetHash)
 			cache[snippetHash] = incomingJsonnet
 		} else {
-			log.Printf("cache hit for %s\n", snippetHash)
+			log.Printf("cache hit for %s, updating snippet\n", snippetHash)
+			cache[snippetHash] = incomingJsonnet
 		}
 		shareMsg := fmt.Sprintf("Link: %s/share/%s\n", shareAddress, snippetHash)
 		w.Write([]byte(shareMsg))


### PR DESCRIPTION
This occurs when comments are placed within the Jsonnet.

Comments should be preserved, so we can store them along with the snippet and allow for updating on hits.