### PR TITLE
fix: remove placeholder for shared snippet

### DIFF
--- a/internal/components/components.templ
+++ b/internal/components/components.templ
@@ -45,7 +45,7 @@ templ jsonnetDisplay(sharedHash string) {
     <div class="jsonnet-editor" id="jsonnet-container">
         <form id="jsonnet-form">
             if sharedHash != "" {
-                <textarea name="jsonnet-input" hx-get={ fmt.Sprintf("/api/share/%s", sharedHash) } hx-trigger="load" placeholder={ fmt.Sprintf("%s", sharedHash) } id="jsonnet-input"></textarea>
+                <textarea name="jsonnet-input" hx-get={ fmt.Sprintf("/api/share/%s", sharedHash) } hx-trigger="load" id="jsonnet-input"></textarea>
             } else {
                 <textarea name="jsonnet-input" autofocus id="jsonnet-input" placeholder="Type your Jsonnet here..."></textarea>
             }

--- a/internal/components/components_templ.go
+++ b/internal/components/components_templ.go
@@ -163,20 +163,7 @@ func jsonnetDisplay(sharedHash string) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("\" hx-trigger=\"load\" placeholder=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var7 string
-			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%s", sharedHash))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/components/components.templ`, Line: 48, Col: 160}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("\" id=\"jsonnet-input\"></textarea> ")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("\" hx-trigger=\"load\" id=\"jsonnet-input\"></textarea> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -205,9 +192,9 @@ func RootPage() templ.Component {
 			defer templ.ReleaseBuffer(templ_7745c5c3_Buffer)
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var8 == nil {
-			templ_7745c5c3_Var8 = templ.NopComponent
+		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var7 == nil {
+			templ_7745c5c3_Var7 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<html>")


### PR DESCRIPTION
Stops the shared snippet hash showing up as the placeholder text for the `textarea`
