### PR TITLE
feat: add tests for api http handlers

### DIFF
--- a/internal/server/routes/backend.go
+++ b/internal/server/routes/backend.go
@@ -31,11 +31,10 @@ func HandleRun(state *state.State) http.HandlerFunc {
 		}
 
 		incomingJsonnet := r.FormValue("jsonnet-input")
-		evaluated, fmtErr := state.Vm.EvaluateAnonymousSnippet("", incomingJsonnet)
-		if fmtErr != nil {
-			errMsg := fmt.Errorf("Invalid Jsonnet: %w", fmtErr)
+		evaluated, err := state.EvaluateSnippet(incomingJsonnet)
+		if err != nil {
 			// TODO: display an error for the bad req rather than using a 200
-			w.Write([]byte(errMsg.Error()))
+			w.Write([]byte(err.Error()))
 			return
 		}
 
@@ -63,8 +62,8 @@ func HandleCreateShare(state *state.State) http.HandlerFunc {
 		}
 
 		incomingJsonnet := r.FormValue("jsonnet-input")
-		_, fmtErr := state.Vm.EvaluateAnonymousSnippet("", incomingJsonnet)
-		if fmtErr != nil {
+		_, err = state.EvaluateSnippet(incomingJsonnet)
+		if err != nil {
 			// TODO: display an error for the bad req rather than using a 200
 			w.Write([]byte("Share is not available for invalid Jsonnet. Run your snippet to see the result."))
 			return

--- a/internal/server/routes/backend_test.go
+++ b/internal/server/routes/backend_test.go
@@ -1,0 +1,46 @@
+package routes_test
+
+import (
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/google/go-jsonnet"
+	"github.com/jdockerty/jsonnet-playground/internal/server/routes"
+	"github.com/jdockerty/jsonnet-playground/internal/server/state"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHandleRun(t *testing.T) {
+
+	vm := jsonnet.MakeVM()
+	tests := []struct {
+		name       string
+		input      string
+		shouldFail bool
+	}{
+		{name: "hello-world", input: "{hello: 'world'}", shouldFail: false},
+		{name: "blank", input: "{}", shouldFail: false},
+		{name: "invalid-jsonnet", input: "{", shouldFail: true},
+		{name: "invalid-jsonnet-2", input: "{hello:}", shouldFail: true},
+	}
+
+	for _, tc := range tests {
+		data := url.Values{}
+		data.Add("jsonnet-input", tc.input)
+
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/api/run", nil)
+		req.PostForm = data
+
+		handler := routes.HandleRun(state.New("https://example.com"))
+		handler.ServeHTTP(rec, req)
+
+		if tc.shouldFail {
+			assert.Contains(t, rec.Body.String(), "Invalid Jsonnet")
+			return
+		}
+		expected, _ := vm.EvaluateAnonymousSnippet("", tc.input)
+		assert.Equal(t, rec.Body.String(), expected, "[%s] expected: %s, got: %s", tc.name, expected, rec.Body.String())
+	}
+}

--- a/internal/server/routes/backend_test.go
+++ b/internal/server/routes/backend_test.go
@@ -1,6 +1,9 @@
 package routes_test
 
 import (
+	"crypto/sha512"
+	"encoding/hex"
+	"fmt"
 	"net/http/httptest"
 	"net/url"
 	"testing"
@@ -42,5 +45,39 @@ func TestHandleRun(t *testing.T) {
 		}
 		expected, _ := vm.EvaluateAnonymousSnippet("", tc.input)
 		assert.Equal(t, rec.Body.String(), expected, "[%s] expected: %s, got: %s", tc.name, expected, rec.Body.String())
+	}
+}
+
+func TestHandleShare(t *testing.T) {
+
+	tests := []struct {
+		name       string
+		input      string
+		shouldFail bool
+	}{
+		{name: "hello-world", input: "{hello: 'world'}", shouldFail: false},
+		{name: "blank", input: "{}", shouldFail: false},
+		{name: "invalid-jsonnet", input: "{", shouldFail: true},
+		{name: "invalid-jsonnet-2", input: "{hello:}", shouldFail: true},
+	}
+
+	for _, tc := range tests {
+		data := url.Values{}
+		data.Add("jsonnet-input", tc.input)
+
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/api/share", nil)
+		req.PostForm = data
+
+		handler := routes.HandleCreateShare(state.New("https://example.com"))
+		handler.ServeHTTP(rec, req)
+
+		if tc.shouldFail {
+			assert.Contains(t, rec.Body.String(), "Share is not available for invalid Jsonnet")
+			return
+		}
+		snippetHash := hex.EncodeToString(sha512.New().Sum([]byte(tc.input)))[:15]
+		expected := fmt.Sprintf("Link: https://example.com/share/%s", snippetHash)
+		assert.Equal(t, rec.Body.String(), expected, "expected: %s, got: %s", tc.name, expected, rec.Body.String())
 	}
 }

--- a/internal/server/state/state.go
+++ b/internal/server/state/state.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"crypto/sha512"
+	"fmt"
 	"hash"
 
 	"github.com/google/go-jsonnet"
@@ -25,6 +26,15 @@ type State struct {
 	Vm     *jsonnet.VM
 	Hasher hash.Hash
 	Config *Config
+}
+
+func (s *State) EvaluateSnippet(snippet string) (string, error) {
+	evaluated, fmtErr := s.Vm.EvaluateAnonymousSnippet("", snippet)
+	if fmtErr != nil {
+		// TODO: display an error for the bad req rather than using a 200
+		return "", fmt.Errorf("Invalid Jsonnet: %w", fmtErr)
+	}
+	return evaluated, nil
 }
 
 // Config contains server configuration

--- a/internal/server/state/state_test.go
+++ b/internal/server/state/state_test.go
@@ -1,0 +1,22 @@
+package state_test
+
+import (
+	"testing"
+
+	"github.com/jdockerty/jsonnet-playground/internal/server/state"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEvaluateSnippet(t *testing.T) {
+	s := state.New("")
+
+	eval, _ := s.EvaluateSnippet("{}")
+	assert.Equal(t, eval, "{ }\n")
+
+	eval, _ = s.EvaluateSnippet("{hello: 'world'}")
+	expected := `{
+   "hello": "world"
+}
+`
+	assert.Equal(t, eval, expected)
+}


### PR DESCRIPTION
Helps with https://github.com/jdockerty/jsonnet-playground/issues/2 so that the functionality can be verified to still be working when altering the underlying libraries.