### PR TITLE
feat: format functionality

### DIFF
--- a/internal/components/components.templ
+++ b/internal/components/components.templ
@@ -89,6 +89,13 @@ templ jsonnetDisplay(sharedHash string) {
             >
             Share
             </button>
+            <button
+                type="submit"
+                hx-post="/api/format"
+                hx-target="#jsonnet-input"
+            >
+            Format
+            </button>
             <div class="share-container">
             <p id="share-output"></p>
             </div>

--- a/internal/components/components.templ
+++ b/internal/components/components.templ
@@ -41,6 +41,26 @@ templ title() {
     </header>
 }
 
+// Hacky function to replace the textarea with formatted Jsonnet.
+//
+// TODO(jdockerty): there may be a nicer way to do this with htmx, but disabling the
+// functionality of the hx-post and replacing the textarea value did not work
+// in the same way as the other htmx swaps, it had very odd behaviour instead.
+script handleFormat() {
+    var textarea = document.getElementById('jsonnet-input');
+    var data = new FormData();
+    data.append("jsonnet-input", textarea.value);
+    fetch("/api/format", {
+        // Using URLSearchParams means we send the expected www-form-url-encoded data.
+        // https://developer.mozilla.org/en-US/docs/Web/API/FormData
+        body: new URLSearchParams(data),
+        method: 'POST'
+    }).then(async (x) => {
+        textarea.value = await x.text();
+        htmx.process(document.body);
+    });
+}
+
 // Allow tab/shift-tab for (de)indentation within the input textarea.
 script allowTabs() {
     var textarea = document.getElementById('jsonnet-input');
@@ -71,7 +91,7 @@ templ jsonnetDisplay(sharedHash string) {
                 if sharedHash != "" {
                     hx-get={ fmt.Sprintf("/api/share/%s", sharedHash) } hx-trigger="load"
                 } else {
-                    autofocus id="jsonnet-input" placeholder="Type your Jsonnet here..."
+                    autofocus placeholder="Type your Jsonnet here..."
                 }
                 >
                 </textarea>
@@ -90,9 +110,8 @@ templ jsonnetDisplay(sharedHash string) {
             Share
             </button>
             <button
-                type="submit"
-                hx-post="/api/format"
-                hx-target="#jsonnet-input"
+                type="button"
+                onClick={ handleFormat() }
             >
             Format
             </button>

--- a/internal/components/components.templ
+++ b/internal/components/components.templ
@@ -47,17 +47,21 @@ templ title() {
 // functionality of the hx-post and replacing the textarea value did not work
 // in the same way as the other htmx swaps, it had very odd behaviour instead.
 script handleFormat() {
-    var textarea = document.getElementById('jsonnet-input');
     var data = new FormData();
-    data.append("jsonnet-input", textarea.value);
+    data.append("jsonnet-input", jsonnetInput.value);
     fetch("/api/format", {
         // Using URLSearchParams means we send the expected www-form-url-encoded data.
         // https://developer.mozilla.org/en-US/docs/Web/API/FormData
         body: new URLSearchParams(data),
         method: 'POST'
-    }).then(async (x) => {
-        // TODO: handle error into output box
-        textarea.value = await x.text();
+    }).then(async (resp) => {
+        if (resp.status === 400) {
+            // Use the same area for share errors to avoid issues with interacting
+            // with the regular jsonnet output box.
+            document.getElementById('share-output').innerText = await resp.text();
+        } else {
+            document.getElementById('jsonnet-input').value = await resp.text();
+        }
         htmx.process(document.body);
     });
 }

--- a/internal/components/components.templ
+++ b/internal/components/components.templ
@@ -56,6 +56,7 @@ script handleFormat() {
         body: new URLSearchParams(data),
         method: 'POST'
     }).then(async (x) => {
+        // TODO: handle error into output box
         textarea.value = await x.text();
         htmx.process(document.body);
     });

--- a/internal/components/components_templ.go
+++ b/internal/components/components_templ.go
@@ -219,7 +219,7 @@ func jsonnetDisplay(sharedHash string) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("></textarea> <button type=\"submit\" hx-post=\"/api/run\" hx-target=\"#jsonnet-output-container\">Run</button> <button type=\"submit\" hx-post=\"/api/share\" hx-target=\"#share-output\">Share</button><div class=\"share-container\"><p id=\"share-output\"></p></div></form><div class=\"jsonnet-output\"><textarea tabindex=\"-1\" id=\"jsonnet-output-container\" readonly placeholder=\"Evaluated Jsonnet will be displayed here\"></textarea></div></div>")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("></textarea> <button type=\"submit\" hx-post=\"/api/run\" hx-target=\"#jsonnet-output-container\">Run</button> <button type=\"submit\" hx-post=\"/api/share\" hx-target=\"#share-output\">Share</button> <button type=\"submit\" hx-post=\"/api/format\" hx-target=\"#jsonnet-input\">Format</button><div class=\"share-container\"><p id=\"share-output\"></p></div></form><div class=\"jsonnet-output\"><textarea tabindex=\"-1\" id=\"jsonnet-output-container\" readonly placeholder=\"Evaluated Jsonnet will be displayed here\"></textarea></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/components/components_templ.go
+++ b/internal/components/components_templ.go
@@ -139,8 +139,8 @@ func title() templ.Component {
 // in the same way as the other htmx swaps, it had very odd behaviour instead.
 func handleFormat() templ.ComponentScript {
 	return templ.ComponentScript{
-		Name: `__templ_handleFormat_ee7f`,
-		Function: `function __templ_handleFormat_ee7f(){var textarea = document.getElementById('jsonnet-input');
+		Name: `__templ_handleFormat_8779`,
+		Function: `function __templ_handleFormat_8779(){var textarea = document.getElementById('jsonnet-input');
     var data = new FormData();
     data.append("jsonnet-input", textarea.value);
     fetch("/api/format", {
@@ -149,12 +149,13 @@ func handleFormat() templ.ComponentScript {
         body: new URLSearchParams(data),
         method: 'POST'
     }).then(async (x) => {
+        // TODO: handle error into output box
         textarea.value = await x.text();
         htmx.process(document.body);
     });
 }`,
-		Call:       templ.SafeScript(`__templ_handleFormat_ee7f`),
-		CallInline: templ.SafeScriptInline(`__templ_handleFormat_ee7f`),
+		Call:       templ.SafeScript(`__templ_handleFormat_8779`),
+		CallInline: templ.SafeScriptInline(`__templ_handleFormat_8779`),
 	}
 }
 
@@ -229,7 +230,7 @@ func jsonnetDisplay(sharedHash string) templ.Component {
 			var templ_7745c5c3_Var7 string
 			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("/api/share/%s", sharedHash))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/components/components.templ`, Line: 92, Col: 69}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/components/components.templ`, Line: 93, Col: 69}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 			if templ_7745c5c3_Err != nil {

--- a/internal/components/components_templ.go
+++ b/internal/components/components_templ.go
@@ -132,6 +132,32 @@ func title() templ.Component {
 	})
 }
 
+// Hacky function to replace the textarea with formatted Jsonnet.
+//
+// TODO(jdockerty): there may be a nicer way to do this with htmx, but disabling the
+// functionality of the hx-post and replacing the textarea value did not work
+// in the same way as the other htmx swaps, it had very odd behaviour instead.
+func handleFormat() templ.ComponentScript {
+	return templ.ComponentScript{
+		Name: `__templ_handleFormat_ee7f`,
+		Function: `function __templ_handleFormat_ee7f(){var textarea = document.getElementById('jsonnet-input');
+    var data = new FormData();
+    data.append("jsonnet-input", textarea.value);
+    fetch("/api/format", {
+        // Using URLSearchParams means we send the expected www-form-url-encoded data.
+        // https://developer.mozilla.org/en-US/docs/Web/API/FormData
+        body: new URLSearchParams(data),
+        method: 'POST'
+    }).then(async (x) => {
+        textarea.value = await x.text();
+        htmx.process(document.body);
+    });
+}`,
+		Call:       templ.SafeScript(`__templ_handleFormat_ee7f`),
+		CallInline: templ.SafeScriptInline(`__templ_handleFormat_ee7f`),
+	}
+}
+
 // Allow tab/shift-tab for (de)indentation within the input textarea.
 func allowTabs() templ.ComponentScript {
 	return templ.ComponentScript{
@@ -203,7 +229,7 @@ func jsonnetDisplay(sharedHash string) templ.Component {
 			var templ_7745c5c3_Var7 string
 			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("/api/share/%s", sharedHash))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/components/components.templ`, Line: 72, Col: 69}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/components/components.templ`, Line: 92, Col: 69}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 			if templ_7745c5c3_Err != nil {
@@ -214,12 +240,29 @@ func jsonnetDisplay(sharedHash string) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(" autofocus id=\"jsonnet-input\" placeholder=\"Type your Jsonnet here...\"")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(" autofocus placeholder=\"Type your Jsonnet here...\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("></textarea> <button type=\"submit\" hx-post=\"/api/run\" hx-target=\"#jsonnet-output-container\">Run</button> <button type=\"submit\" hx-post=\"/api/share\" hx-target=\"#share-output\">Share</button> <button type=\"submit\" hx-post=\"/api/format\" hx-target=\"#jsonnet-input\">Format</button><div class=\"share-container\"><p id=\"share-output\"></p></div></form><div class=\"jsonnet-output\"><textarea tabindex=\"-1\" id=\"jsonnet-output-container\" readonly placeholder=\"Evaluated Jsonnet will be displayed here\"></textarea></div></div>")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("></textarea> <button type=\"submit\" hx-post=\"/api/run\" hx-target=\"#jsonnet-output-container\">Run</button> <button type=\"submit\" hx-post=\"/api/share\" hx-target=\"#share-output\">Share</button> ")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templ.RenderScriptItems(ctx, templ_7745c5c3_Buffer, handleFormat())
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<button type=\"button\" onClick=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var8 templ.ComponentScript = handleFormat()
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var8.Call)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("\">Format</button><div class=\"share-container\"><p id=\"share-output\"></p></div></form><div class=\"jsonnet-output\"><textarea tabindex=\"-1\" id=\"jsonnet-output-container\" readonly placeholder=\"Evaluated Jsonnet will be displayed here\"></textarea></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -238,9 +281,9 @@ func RootPage() templ.Component {
 			defer templ.ReleaseBuffer(templ_7745c5c3_Buffer)
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var8 == nil {
-			templ_7745c5c3_Var8 = templ.NopComponent
+		templ_7745c5c3_Var9 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var9 == nil {
+			templ_7745c5c3_Var9 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<html>")

--- a/internal/components/components_templ.go
+++ b/internal/components/components_templ.go
@@ -139,23 +139,27 @@ func title() templ.Component {
 // in the same way as the other htmx swaps, it had very odd behaviour instead.
 func handleFormat() templ.ComponentScript {
 	return templ.ComponentScript{
-		Name: `__templ_handleFormat_8779`,
-		Function: `function __templ_handleFormat_8779(){var textarea = document.getElementById('jsonnet-input');
-    var data = new FormData();
-    data.append("jsonnet-input", textarea.value);
+		Name: `__templ_handleFormat_31cd`,
+		Function: `function __templ_handleFormat_31cd(){var data = new FormData();
+    data.append("jsonnet-input", jsonnetInput.value);
     fetch("/api/format", {
         // Using URLSearchParams means we send the expected www-form-url-encoded data.
         // https://developer.mozilla.org/en-US/docs/Web/API/FormData
         body: new URLSearchParams(data),
         method: 'POST'
-    }).then(async (x) => {
-        // TODO: handle error into output box
-        textarea.value = await x.text();
+    }).then(async (resp) => {
+        if (resp.status === 400) {
+            // Use the same area for share errors to avoid issues with interacting
+            // with the regular jsonnet output box.
+            document.getElementById('share-output').innerText = await resp.text();
+        } else {
+            document.getElementById('jsonnet-input').value = await resp.text();
+        }
         htmx.process(document.body);
     });
 }`,
-		Call:       templ.SafeScript(`__templ_handleFormat_8779`),
-		CallInline: templ.SafeScriptInline(`__templ_handleFormat_8779`),
+		Call:       templ.SafeScript(`__templ_handleFormat_31cd`),
+		CallInline: templ.SafeScriptInline(`__templ_handleFormat_31cd`),
 	}
 }
 
@@ -230,7 +234,7 @@ func jsonnetDisplay(sharedHash string) templ.Component {
 			var templ_7745c5c3_Var7 string
 			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("/api/share/%s", sharedHash))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/components/components.templ`, Line: 93, Col: 69}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/components/components.templ`, Line: 97, Col: 69}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 			if templ_7745c5c3_Err != nil {

--- a/internal/server/routes/backend.go
+++ b/internal/server/routes/backend.go
@@ -103,3 +103,31 @@ func HandleGetShare(state *state.State) http.HandlerFunc {
 		w.Write([]byte(snippet))
 	}
 }
+
+// Format the input Jsonnet according to the standard jsonnetfmt rules.
+func HandleFormat(state *state.State) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "must be GET", 400)
+			return
+		}
+		log.Println("Formatting snippet")
+
+		err := r.ParseForm()
+		if err != nil {
+			http.Error(w, "unable to parse form", 400)
+			return
+		}
+
+		incomingJsonnet := r.FormValue("jsonnet-input")
+		log.Println("Incoming:", incomingJsonnet)
+		formattedJsonnet, err := state.FormatSnippet(incomingJsonnet)
+		if err != nil {
+			http.Error(w, "unable to format jsonnet", 400)
+			return
+		}
+		log.Println("Formatted:", formattedJsonnet)
+		w.Write([]byte(formattedJsonnet))
+		return
+	}
+}

--- a/internal/server/routes/backend.go
+++ b/internal/server/routes/backend.go
@@ -108,7 +108,7 @@ func HandleGetShare(state *state.State) http.HandlerFunc {
 func HandleFormat(state *state.State) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
-			http.Error(w, "must be GET", 400)
+			http.Error(w, "must be POST", 400)
 			return
 		}
 		log.Println("Formatting snippet")

--- a/internal/server/routes/backend.go
+++ b/internal/server/routes/backend.go
@@ -123,7 +123,7 @@ func HandleFormat(state *state.State) http.HandlerFunc {
 		log.Println("Incoming:", incomingJsonnet)
 		formattedJsonnet, err := state.FormatSnippet(incomingJsonnet)
 		if err != nil {
-			http.Error(w, "unable to format jsonnet", 400)
+			http.Error(w, "Format is not available for invalid Jsonnet. Run your snippet to see the result.", 400)
 			return
 		}
 		log.Println("Formatted:", formattedJsonnet)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -34,6 +34,7 @@ func (srv *PlaygroundServer) Routes() error {
 	// Backend/API routes
 	http.HandleFunc("/api/health", routes.Health())
 	http.HandleFunc("/api/run", routes.HandleRun(srv.State))
+	http.HandleFunc("/api/format", routes.HandleFormat(srv.State))
 	http.HandleFunc("/api/share", routes.HandleCreateShare(srv.State))
 	http.HandleFunc("/api/share/{shareHash}", routes.HandleGetShare(srv.State))
 	return nil

--- a/internal/server/state/state.go
+++ b/internal/server/state/state.go
@@ -46,10 +46,15 @@ func (s *State) EvaluateSnippet(snippet string) (string, error) {
 }
 
 func (s *State) FormatSnippet(snippet string) (string, error) {
+	_, err := s.EvaluateSnippet(snippet)
+	if err != nil {
+		return "", err
+	}
+
 	opts := formatter.DefaultOptions()
 	output, err := formatter.Format(PlaygroundFile, snippet, opts)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 	return output, nil
 }

--- a/internal/server/state/state.go
+++ b/internal/server/state/state.go
@@ -6,6 +6,7 @@ import (
 	"hash"
 
 	"github.com/google/go-jsonnet"
+	"github.com/google/go-jsonnet/formatter"
 	"github.com/kubecfg/kubecfg/pkg/kubecfg"
 )
 
@@ -42,6 +43,15 @@ func (s *State) EvaluateSnippet(snippet string) (string, error) {
 		return "", fmt.Errorf("Invalid Jsonnet: %w", fmtErr)
 	}
 	return evaluated, nil
+}
+
+func (s *State) FormatSnippet(snippet string) (string, error) {
+	opts := formatter.DefaultOptions()
+	output, err := formatter.Format(PlaygroundFile, snippet, opts)
+	if err != nil {
+		return "", nil
+	}
+	return output, nil
 }
 
 // Config contains server configuration

--- a/internal/server/state/state_test.go
+++ b/internal/server/state/state_test.go
@@ -28,3 +28,10 @@ func TestEvaluateKubecfg(t *testing.T) {
 	eval, _ := s.EvaluateSnippet(string(f))
 	assert.Equal(t, string(expected), eval)
 }
+
+func TestFormat(t *testing.T) {
+	s := state.New("")
+
+	eval, _ := s.FormatSnippet(`{hello:"world"}`)
+	assert.Equal(t, eval, "{ hello: 'world' }\n")
+}


### PR DESCRIPTION
Closes https://github.com/jdockerty/jsonnet-playground/issues/10

This adds what would be expected from some very basic formatting functionality. I.e. click the button and your Jsonnet is formatted in the same way that it would be using `jsonnetfmt`. 

The `handleFormat` JavaScript is a little hacky, as the `hx-swap`/`hx-post` did not work in the same way as the other elements for replacing the `textarea` with the response from the server. I'm not quite sure why this is, but what is done here works and is good enough for now :+1: 