### PR TITLE
feat: disallow file imports

### DIFF
--- a/internal/server/routes/backend.go
+++ b/internal/server/routes/backend.go
@@ -27,7 +27,7 @@ func Health() http.HandlerFunc {
 func HandleRun(state *state.State) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
-			http.Error(w, "must be POST", 400)
+			http.Error(w, "must be POST", http.StatusBadRequest)
 			return
 		}
 
@@ -53,7 +53,7 @@ func HandleRun(state *state.State) http.HandlerFunc {
 func HandleCreateShare(state *state.State) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
-			http.Error(w, "must be POST", 400)
+			http.Error(w, "must be POST", http.StatusBadRequest)
 			return
 		}
 
@@ -84,7 +84,7 @@ func HandleCreateShare(state *state.State) http.HandlerFunc {
 func HandleGetShare(state *state.State) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
-			http.Error(w, "must be GET", 400)
+			http.Error(w, "must be GET", http.StatusBadRequest)
 			return
 		}
 		shareHash := r.PathValue("shareHash")
@@ -105,7 +105,7 @@ func HandleGetShare(state *state.State) http.HandlerFunc {
 func HandleFormat(state *state.State) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
-			http.Error(w, "must be POST", 400)
+			http.Error(w, "must be POST", http.StatusBadRequest)
 			return
 		}
 
@@ -114,7 +114,7 @@ func HandleFormat(state *state.State) http.HandlerFunc {
 		formattedJsonnet, err := state.FormatSnippet(incomingJsonnet)
 		if err != nil {
 			log.Println("Unable to format invalid Jsonnet")
-			http.Error(w, "Format is not available for invalid Jsonnet. Run your snippet to see the result.", 400)
+			http.Error(w, "Format is not available for invalid Jsonnet. Run your snippet to see the result.", http.StatusBadRequest)
 			return
 		}
 		log.Println("Formatted:", formattedJsonnet)
@@ -126,7 +126,7 @@ func DisableFileImports(next http.Handler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		err := r.ParseForm()
 		if err != nil {
-			http.Error(w, "unable to parse form", 400)
+			http.Error(w, "unable to parse form", http.StatusBadRequest)
 			return
 		}
 		incomingJsonnet := r.FormValue("jsonnet-input")

--- a/internal/server/routes/backend.go
+++ b/internal/server/routes/backend.go
@@ -122,6 +122,9 @@ func HandleFormat(state *state.State) http.HandlerFunc {
 	}
 }
 
+// Middleware to stop Jsonnet snippets which contain file:///, typically paired
+// with an import, being used and becoming shareable. These are rejected before
+// running through the Jsonnet VM and a generic error is displayed.
 func DisableFileImports(next http.Handler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		err := r.ParseForm()
@@ -132,7 +135,7 @@ func DisableFileImports(next http.Handler) http.HandlerFunc {
 		incomingJsonnet := r.FormValue("jsonnet-input")
 		if ok := disallowFileImports.Match([]byte(incomingJsonnet)); ok {
 			log.Println("Attempt to import file", incomingJsonnet)
-			w.Write([]byte("File imports are disabled."))
+			_, _ = w.Write([]byte("File imports are disabled."))
 			return
 		}
 		next.ServeHTTP(w, r)

--- a/internal/server/routes/backend.go
+++ b/internal/server/routes/backend.go
@@ -34,12 +34,13 @@ func HandleRun(state *state.State) http.HandlerFunc {
 		incomingJsonnet := r.FormValue("jsonnet-input")
 		evaluated, err := state.EvaluateSnippet(incomingJsonnet)
 		if err != nil {
+			log.Printf("Attempted to run invalid snippet: %s", incomingJsonnet)
 			// TODO: display an error for the bad req rather than using a 200
 			_, _ = w.Write([]byte(err.Error()))
 			return
 		}
 
-		log.Printf("Snippet:\n%s\n", evaluated)
+		log.Printf("Snippet:\n%s", evaluated)
 		_, _ = w.Write([]byte(evaluated))
 	}
 }
@@ -59,6 +60,7 @@ func HandleCreateShare(state *state.State) http.HandlerFunc {
 		incomingJsonnet := r.FormValue("jsonnet-input")
 		_, err := state.EvaluateSnippet(incomingJsonnet)
 		if err != nil {
+			log.Println("Attempted share of invalid snippet", incomingJsonnet)
 			// TODO: display an error for the bad req rather than using a 200
 			_, _ = w.Write([]byte("Share is not available for invalid Jsonnet. Run your snippet to see the result."))
 			return
@@ -106,12 +108,12 @@ func HandleFormat(state *state.State) http.HandlerFunc {
 			http.Error(w, "must be POST", 400)
 			return
 		}
-		log.Println("Formatting snippet")
 
 		incomingJsonnet := r.FormValue("jsonnet-input")
-		log.Println("Incoming:", incomingJsonnet)
+		log.Println("Attempting to format:", incomingJsonnet)
 		formattedJsonnet, err := state.FormatSnippet(incomingJsonnet)
 		if err != nil {
+			log.Println("Unable to format invalid Jsonnet")
 			http.Error(w, "Format is not available for invalid Jsonnet. Run your snippet to see the result.", 400)
 			return
 		}

--- a/internal/server/routes/backend_test.go
+++ b/internal/server/routes/backend_test.go
@@ -36,8 +36,9 @@ func TestHandleRun(t *testing.T) {
 		{name: "hello-world", input: "{hello: 'world'}", expected: "../../../testdata/hello-world.json", shouldFail: false},
 		{name: "blank", input: "{}", expected: "../../../testdata/blank.json", shouldFail: false},
 		{name: "kubecfg", input: "local kubecfg = import 'internal:///kubecfg.libsonnet';\n{myVeryNestedObj:: { foo: { bar: { baz: { qux: 'some-val' }}}}, hasValue: kubecfg.objectHasPathAll($.myVeryNestedObj, 'foo.bar.baz.qux')}", expected: "../../../testdata/kubecfg.json", shouldFail: false},
-		{name: "invalid-jsonnet", input: "{", expected: "", shouldFail: true},
-		{name: "invalid-jsonnet-2", input: "{hello:}", expected: "", shouldFail: true},
+		{name: "invalid-jsonnet", input: "{", expected: "Invalid Jsonnet", shouldFail: true},
+		{name: "invalid-jsonnet-2", input: "{hello:}", expected: "Invalid Jsonnet", shouldFail: true},
+		{name: "file-import-jsonnet", input: "local f = import 'file:///proc/self/environ'; error 'test' + f", expected: "File imports are disabled", shouldFail: true},
 	}
 
 	for _, tc := range tests {
@@ -52,7 +53,7 @@ func TestHandleRun(t *testing.T) {
 		handler.ServeHTTP(rec, req)
 
 		if tc.shouldFail {
-			assert.Contains(t, rec.Body.String(), "Invalid Jsonnet")
+			assert.Contains(t, rec.Body.String(), tc.expected)
 			return
 		}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -33,10 +33,10 @@ func (srv *PlaygroundServer) Routes() error {
 
 	// Backend/API routes
 	http.HandleFunc("/api/health", routes.Health())
-	http.HandleFunc("/api/run", routes.HandleRun(srv.State))
-	http.HandleFunc("/api/format", routes.HandleFormat(srv.State))
-	http.HandleFunc("/api/share", routes.HandleCreateShare(srv.State))
-	http.HandleFunc("/api/share/{shareHash}", routes.HandleGetShare(srv.State))
+	http.HandleFunc("/api/run", routes.DisableFileImports(routes.HandleRun(srv.State)))
+	http.HandleFunc("/api/format", routes.DisableFileImports(routes.HandleFormat(srv.State)))
+	http.HandleFunc("/api/share", routes.DisableFileImports(routes.HandleCreateShare(srv.State)))
+	http.HandleFunc("/api/share/{shareHash}", routes.DisableFileImports(routes.HandleGetShare(srv.State)))
 	return nil
 }
 


### PR DESCRIPTION
Adds basic middleware to stop the use of `import file:///<known_files>`, which can be used to snoop through the container file system.

I believe this stops at information disclosure, considering Jsonnet is hermetic and cannot take action on a system, but disabling the use of file imports here is okay - there are no files to import except the internal `kubecfg.libsonnet` too, which comes from the embedded filesystem of `kubecfg` and the explicit `internal:///` prefix.

This middleware also encompasses the `r.ParseForm` requirement, which is now removed from all other handlers.
