### PR TITLE
feat: add slog usage

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,4 +22,4 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: v1.58
-
+          args: --timeout 2m

--- a/cmd/server/cmd.go
+++ b/cmd/server/cmd.go
@@ -4,6 +4,9 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"log/slog"
+	"os"
+	"strings"
 
 	"github.com/jdockerty/jsonnet-playground/internal/server"
 	"github.com/jdockerty/jsonnet-playground/internal/server/state"
@@ -13,23 +16,40 @@ var (
 	host         string
 	port         int
 	shareAddress string
+	logLevel     string
 )
 
 func init() {
 	flag.StringVar(&host, "host", "127.0.0.1", "Host address to bind to")
 	flag.StringVar(&shareAddress, "share-domain", "http://127.0.0.1", "Address prefix when sharing snippets")
+	flag.StringVar(&logLevel, "log-level", "info", "Log verbosity level")
 	flag.IntVar(&port, "port", 8080, "Port binding for the server")
 	flag.Parse()
 }
 
+func parseLogLevel(level string) slog.Level {
+	switch strings.ToLower(level) {
+	case "debug":
+		return slog.LevelDebug.Level()
+	case "error":
+		return slog.LevelError.Level()
+	case "warn":
+		return slog.LevelWarn.Level()
+	default:
+		return slog.LevelInfo.Level()
+	}
+}
+
 func main() {
 	bindAddress := fmt.Sprintf("%s:%d", host, port)
-	state := state.New(shareAddress)
+	logLevel := parseLogLevel(logLevel)
+	log.Println("Log level set to", logLevel)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: logLevel}))
+	state := state.NewWithLogger(shareAddress, logger)
 	playground := &server.PlaygroundServer{
 		State: state,
 	}
 
-	log.Printf("Listening on %s\n", bindAddress)
+	slog.Info("Listening on", "address", bindAddress)
 	log.Fatal(playground.Serve(bindAddress))
-
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -32,11 +32,11 @@ func (srv *PlaygroundServer) Routes() error {
 	http.HandleFunc("/share/{shareHash}", routes.HandleShare(srv.State))
 
 	// Backend/API routes
-	http.HandleFunc("/api/health", routes.Health())
-	http.HandleFunc("/api/run", routes.DisableFileImports(routes.HandleRun(srv.State)))
-	http.HandleFunc("/api/format", routes.DisableFileImports(routes.HandleFormat(srv.State)))
-	http.HandleFunc("/api/share", routes.DisableFileImports(routes.HandleCreateShare(srv.State)))
-	http.HandleFunc("/api/share/{shareHash}", routes.DisableFileImports(routes.HandleGetShare(srv.State)))
+	http.HandleFunc("/api/health", routes.Health(srv.State))
+	http.HandleFunc("/api/run", routes.DisableFileImports(srv.State, routes.HandleRun(srv.State)))
+	http.HandleFunc("/api/format", routes.DisableFileImports(srv.State, routes.HandleFormat(srv.State)))
+	http.HandleFunc("/api/share", routes.DisableFileImports(srv.State, routes.HandleCreateShare(srv.State)))
+	http.HandleFunc("/api/share/{shareHash}", routes.DisableFileImports(srv.State, routes.HandleGetShare(srv.State)))
 	http.HandleFunc("/api/versions", routes.HandleVersions(srv.State))
 	return nil
 }

--- a/internal/server/state/state.go
+++ b/internal/server/state/state.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha512"
 	"fmt"
 	"hash"
+	"log/slog"
 
 	"github.com/google/go-jsonnet"
 	"github.com/google/go-jsonnet/formatter"
@@ -17,6 +18,11 @@ const PlaygroundFile = "play.jsonnet"
 
 // New creates a new default State
 func New(shareAddress string) *State {
+	return NewWithLogger(shareAddress, slog.Default())
+}
+
+// NewWithLogger creates a new default State
+func NewWithLogger(shareAddress string, logger *slog.Logger) *State {
 	vm, _ := kubecfg.JsonnetVM()
 	return &State{
 		Store:  make(map[string]string),
@@ -25,6 +31,7 @@ func New(shareAddress string) *State {
 		Config: &Config{
 			ShareDomain: shareAddress,
 		},
+		Logger: logger,
 	}
 }
 
@@ -34,6 +41,7 @@ type State struct {
 	Vm     *jsonnet.VM
 	Hasher hash.Hash
 	Config *Config
+	Logger *slog.Logger
 }
 
 func (s *State) EvaluateSnippet(snippet string) (string, error) {
@@ -61,5 +69,9 @@ func (s *State) FormatSnippet(snippet string) (string, error) {
 
 // Config contains server configuration
 type Config struct {
+	// ShareDomain is used for the share functionality. The shareable hash is
+	// appended to this value.
+	//
+	// In short, this value should be how the application is accessed.
 	ShareDomain string
 }

--- a/justfile
+++ b/justfile
@@ -22,6 +22,7 @@ run_reload LOG_LEVEL="info":
 deps:
     go install github.com/google/ko@latest
     go install github.com/a-h/templ/cmd/templ@$(go mod edit -json | jq -r '.Require[] | select(.Path | contains("templ")).Version')
+    go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 
 # Run various lint/generation tools
 lint:

--- a/justfile
+++ b/justfile
@@ -11,16 +11,17 @@ build_local:
 push REGISTRY="ghcr.io/jdockerty/jsonnet-playground":
     KO_DOCKER_REPO={{ REGISTRY }} ko build github.com/jdockerty/jsonnet-playground/cmd/server --platform=linux/arm64,linux/amd64
 
-run:
-    KO_DATA_PATH="cmd/server/kodata" go run cmd/server/cmd.go
+run LOG_LEVEL="info":
+    KO_DATA_PATH="cmd/server/kodata" go run cmd/server/cmd.go --log-level {{ LOG_LEVEL }}
 
 # Run the server with hot reloading for templ components
-run_reload:
-    KO_DATA_PATH="cmd/server/kodata" templ generate --watch --proxy="http://127.0.0.1:8080" --cmd='go run cmd/server/cmd.go'
+run_reload LOG_LEVEL="info":
+    KO_DATA_PATH="cmd/server/kodata" templ generate --watch --proxy="http://127.0.0.1:8080" --cmd='go run cmd/server/cmd.go --log-level {{ LOG_LEVEL }}'
 
 # Install required dependencies
 deps:
     go install github.com/google/ko@latest
+    go install github.com/a-h/templ/cmd/templ@$(go mod edit -json | jq -r '.Require[] | select(.Path | contains("templ")).Version')
 
 # Run various lint/generation tools
 lint:


### PR DESCRIPTION
Use `log/slog` package for structured logging capabilities.

This also makes our logging a lot more consumable/presentable to view. Prior to this, raw Jsonnet is dumped into the terminal which is rather difficult to read with larger outputs, now it is placed as k-v pairs into strings which is simpler to digest at a glance.
