### PR TITLE
feat: graceful shutdown

### DIFF
--- a/cmd/server/cmd.go
+++ b/cmd/server/cmd.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"log/slog"
+	"net/http"
 	"os"
 	"os/signal"
 	"strings"
@@ -57,7 +58,11 @@ func main() {
 	playground := server.New(state)
 
 	slog.Info("Listening on", "address", bindAddress)
-	go func() { log.Fatal(playground.Serve()) }()
+	go func() {
+		if err := playground.Serve(); err != http.ErrServerClosed {
+			slog.Error("Unexpected shutdown: %w", err)
+		}
+	}()
 
 	<-ctx.Done()
 	stop()

--- a/cmd/server/cmd.go
+++ b/cmd/server/cmd.go
@@ -60,7 +60,7 @@ func main() {
 	slog.Info("Listening on", "address", bindAddress)
 	go func() {
 		if err := playground.Serve(); err != http.ErrServerClosed {
-			slog.Error("Unexpected shutdown: %w", err)
+			slog.Error("Unexpected shutdown", slog.Any("error", err))
 		}
 	}()
 
@@ -72,7 +72,7 @@ func main() {
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	if err := playground.Server.Shutdown(timeoutCtx); err != nil {
-		slog.Error("Server forced shutdown: %w", err)
+		slog.Error("Server forced shutdown", slog.Any("error", err))
 	}
 
 	slog.Info("Server shutdown")

--- a/internal/server/routes/backend_test.go
+++ b/internal/server/routes/backend_test.go
@@ -49,7 +49,7 @@ func TestHandleRun(t *testing.T) {
 		req := httptest.NewRequest("POST", "/api/run", nil)
 		req.PostForm = data
 
-		handler := routes.HandleRun(state.New("https://example.com"))
+		handler := routes.HandleRun(state.New("127.0.0.1", "https://example.com"))
 		handler.ServeHTTP(rec, req)
 
 		if tc.shouldFail {
@@ -87,7 +87,7 @@ func TestHandleCreateShare(t *testing.T) {
 		req := httptest.NewRequest("POST", "/api/share", nil)
 		req.PostForm = data
 
-		handler := routes.HandleCreateShare(state.New("https://example.com"))
+		handler := routes.HandleCreateShare(state.New("127.0.0.1", "https://example.com"))
 		handler.ServeHTTP(rec, req)
 
 		if tc.shouldFail {
@@ -102,7 +102,7 @@ func TestHandleCreateShare(t *testing.T) {
 
 func TestHandleGetShare(t *testing.T) {
 	assert := assert.New(t)
-	s := state.New("https://example.com")
+	s := state.New("127.0.0.1", "https://example.com")
 	snippet := "{hello: 'world'}"
 	snippetHash := hex.EncodeToString(sha512.New().Sum([]byte(snippet)))[:15]
 
@@ -132,7 +132,7 @@ func TestHandleGetShare(t *testing.T) {
 
 func TestHandleVersions(t *testing.T) {
 	assert := assert.New(t)
-	s := state.New("https://example.com")
+	s := state.New("127.0.0.1", "https://example.com")
 
 	handler := routes.HandleVersions(s)
 	rec := httptest.NewRecorder()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -15,8 +15,6 @@ import (
 type PlaygroundServer struct {
 	Server http.Server
 	State  *state.State
-
-	mux http.ServeMux
 }
 
 func New(state *state.State) *PlaygroundServer {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -37,17 +37,17 @@ func (srv *PlaygroundServer) Routes() error {
 	// Frontend routes
 	rootPage := components.RootPage("")
 	fs := http.FileServer(http.Dir(path))
-	srv.mux.Handle("/assets/", routes.HandleAssets("/assets/", fs))
-	srv.mux.Handle("/", templ.Handler(rootPage))
-	srv.mux.HandleFunc("/share/{shareHash}", routes.HandleShare(srv.State))
+	http.Handle("/assets/", routes.HandleAssets("/assets/", fs))
+	http.Handle("/", templ.Handler(rootPage))
+	http.HandleFunc("/share/{shareHash}", routes.HandleShare(srv.State))
 
 	// Backend/API routes
-	srv.mux.HandleFunc("/api/health", routes.Health(srv.State))
-	srv.mux.HandleFunc("/api/run", routes.DisableFileImports(srv.State, routes.HandleRun(srv.State)))
-	srv.mux.HandleFunc("/api/format", routes.DisableFileImports(srv.State, routes.HandleFormat(srv.State)))
-	srv.mux.HandleFunc("/api/share", routes.DisableFileImports(srv.State, routes.HandleCreateShare(srv.State)))
-	srv.mux.HandleFunc("/api/share/{shareHash}", routes.DisableFileImports(srv.State, routes.HandleGetShare(srv.State)))
-	srv.mux.HandleFunc("/api/versions", routes.HandleVersions(srv.State))
+	http.HandleFunc("/api/health", routes.Health(srv.State))
+	http.HandleFunc("/api/run", routes.DisableFileImports(srv.State, routes.HandleRun(srv.State)))
+	http.HandleFunc("/api/format", routes.DisableFileImports(srv.State, routes.HandleFormat(srv.State)))
+	http.HandleFunc("/api/share", routes.DisableFileImports(srv.State, routes.HandleCreateShare(srv.State)))
+	http.HandleFunc("/api/share/{shareHash}", routes.DisableFileImports(srv.State, routes.HandleGetShare(srv.State)))
+	http.HandleFunc("/api/versions", routes.HandleVersions(srv.State))
 	return nil
 }
 

--- a/internal/server/state/state.go
+++ b/internal/server/state/state.go
@@ -17,12 +17,12 @@ import (
 const PlaygroundFile = "play.jsonnet"
 
 // New creates a new default State
-func New(shareAddress string) *State {
-	return NewWithLogger(shareAddress, slog.Default())
+func New(bindAddress, shareAddress string) *State {
+	return NewWithLogger(bindAddress, shareAddress, slog.Default())
 }
 
 // NewWithLogger creates a new default State
-func NewWithLogger(shareAddress string, logger *slog.Logger) *State {
+func NewWithLogger(bindAddress, shareAddress string, logger *slog.Logger) *State {
 	vm, _ := kubecfg.JsonnetVM()
 	return &State{
 		Store:  make(map[string]string),
@@ -30,6 +30,7 @@ func NewWithLogger(shareAddress string, logger *slog.Logger) *State {
 		Hasher: sha512.New(),
 		Config: &Config{
 			ShareDomain: shareAddress,
+			Address:     bindAddress,
 		},
 		Logger: logger,
 	}
@@ -69,6 +70,10 @@ func (s *State) FormatSnippet(snippet string) (string, error) {
 
 // Config contains server configuration
 type Config struct {
+
+	// Server address binding
+	Address string
+
 	// ShareDomain is used for the share functionality. The shareable hash is
 	// appended to this value.
 	//

--- a/internal/server/state/state_test.go
+++ b/internal/server/state/state_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestEvaluateSnippet(t *testing.T) {
-	s := state.New("")
+	s := state.New("127.0.0.1", "")
 
 	eval, _ := s.EvaluateSnippet("{}")
 	assert.Equal(t, "{ }\n", eval)
@@ -20,7 +20,7 @@ func TestEvaluateSnippet(t *testing.T) {
 }
 
 func TestEvaluateKubecfg(t *testing.T) {
-	s := state.New("")
+	s := state.New("127.0.0.1", "")
 
 	f, _ := os.ReadFile("../../../testdata/kubecfg.jsonnet")
 
@@ -30,7 +30,7 @@ func TestEvaluateKubecfg(t *testing.T) {
 }
 
 func TestFormat(t *testing.T) {
-	s := state.New("")
+	s := state.New("127.0.0.1", "")
 
 	eval, _ := s.FormatSnippet(`{hello:"world"}`)
 	assert.Equal(t, eval, "{ hello: 'world' }\n")


### PR DESCRIPTION
Implement graceful shutdown to the server, so that connections are not immediately severed on deployment trigger/general signal receipt.
