### PR TITLE
feat: share invalid jsonnet

### DIFF
--- a/internal/server/backend_routes.go
+++ b/internal/server/backend_routes.go
@@ -69,10 +69,7 @@ func (srv *PlaygroundServer) HandleCreateShare() http.HandlerFunc {
 		incomingJsonnet := r.FormValue("jsonnet-input")
 		_, err := srv.State.EvaluateSnippet(incomingJsonnet)
 		if err != nil {
-			srv.State.Logger.Error("invalid share", "jsonnet", incomingJsonnet)
-			// TODO: display an error for the bad req rather than using a 200
-			_, _ = w.Write([]byte("Share is not available for invalid Jsonnet. Run your snippet to see the result."))
-			return
+			srv.State.Logger.Error("invalid jsonnet for share", "jsonnet", incomingJsonnet)
 		}
 
 		snippetHash := hex.EncodeToString(srv.State.Hasher.Sum([]byte(incomingJsonnet)))[:15]

--- a/internal/server/backend_routes_test.go
+++ b/internal/server/backend_routes_test.go
@@ -73,11 +73,11 @@ func TestHandleCreateShare(t *testing.T) {
 		input      string
 		shouldFail bool
 	}{
-		{name: "hello-world", input: "{hello: 'world'}", shouldFail: false},
-		{name: "blank", input: "{}", shouldFail: false},
-		{name: "invalid-jsonnet", input: "{", shouldFail: true},
-		{name: "invalid-jsonnet-2", input: "{hello:}", shouldFail: true},
-		{name: "kubecfg", input: "local kubecfg = import 'internal:///kubecfg.libsonnet';\n{k8s: kubecfg.isK8sObject({apiVersion: 'v1', kind: 'Pod', spec: {}})}", shouldFail: false},
+		{name: "hello-world", input: "{hello: 'world'}"},
+		{name: "blank", input: "{}"},
+		{name: "invalid-jsonnet", input: "{"},
+		{name: "invalid-jsonnet-2", input: "{hello:}"},
+		{name: "kubecfg", input: "local kubecfg = import 'internal:///kubecfg.libsonnet';\n{k8s: kubecfg.isK8sObject({apiVersion: 'v1', kind: 'Pod', spec: {}})}"},
 	}
 
 	for _, tc := range tests {
@@ -92,10 +92,6 @@ func TestHandleCreateShare(t *testing.T) {
 		handler := srv.HandleCreateShare()
 		handler.ServeHTTP(rec, req)
 
-		if tc.shouldFail {
-			assert.Contains(t, rec.Body.String(), "Share is not available for invalid Jsonnet")
-			return
-		}
 		snippetHash := hex.EncodeToString(sha512.New().Sum([]byte(tc.input)))[:15]
 		expected := fmt.Sprintf("Link: https://example.com/share/%s", snippetHash)
 		assert.Equal(t, rec.Body.String(), expected, "expected: %s, got: %s", tc.name, expected, rec.Body.String())


### PR DESCRIPTION
Sharing invalid Jsonnet is a valid action.

Prior to this, the evaluated snippet was checked to ensure validity and this would force the snippet to be valid before sharing. Being able to share invalid Jsonnet for examples should also be allowed too. Now the invalid Jsonnet is simply logged.
